### PR TITLE
Support FrameRange

### DIFF
--- a/src/binding/motion.cpp
+++ b/src/binding/motion.cpp
@@ -1,4 +1,5 @@
 #include <flom/motion.hpp>
+#include <flom/range.hpp>
 
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
@@ -38,6 +39,7 @@ void define_motion(py::module &m) {
            })
       .def("dump_json_string", &flom::Motion::dump_json_string)
       .def("frame_at", &flom::Motion::frame_at)
+      .def("frames", &flom::Motion::frames)
       .def("loop", &flom::Motion::loop)
       .def("set_loop", &flom::Motion::set_loop)
       .def("model_id", &flom::Motion::model_id)

--- a/src/binding/ranges.cpp
+++ b/src/binding/ranges.cpp
@@ -13,6 +13,11 @@ void define_ranges(py::module &m) {
       .def("__iter__", [](flom::KeyRange<std::string> &range) {
         return py::make_iterator(range.begin(), range.end());
       });
+
+  py::class_<flom::FrameRange>(m, "FrameRange")
+      .def("__iter__", [](flom::FrameRange &range) {
+        return py::make_iterator(range.begin(), range.end());
+      });
 }
 
 } // namespace flom_py


### PR DESCRIPTION
Fix #1

- `Motion.frames(float)`
- `FrameRange`

depends on DeepL2/flom#16